### PR TITLE
Fix package import and add Docker usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.coverage
+build/
+dist/
+htmlcov/
+.env
+.env.local
+.venv/
+venv/
+env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml setup.py requirements.txt README.md LICENSE MANIFEST.in ./
+COPY finance_mcp ./finance_mcp
+
+RUN pip install --no-cache-dir .
+
+CMD ["finance-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,43 @@ Then add to your Claude Desktop configuration:
 
 Restart Claude Desktop and start asking about stocks! 🎉
 
+### Using uvx
+
+If you use [uv](https://docs.astral.sh/uv/), you can run the published
+package without a manual virtual environment:
+
+```json
+{
+  "mcpServers": {
+    "finance": {
+      "command": "uvx",
+      "args": ["finance-mcp-server"]
+    }
+  }
+}
+```
+
+### Using Docker
+
+Build the local image:
+
+```bash
+docker build -t finance-mcp-server .
+```
+
+Then point your MCP client at the containerized stdio server:
+
+```json
+{
+  "mcpServers": {
+    "finance": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "finance-mcp-server"]
+    }
+  }
+}
+```
+
 ### Manual Installation
 
 ```bash

--- a/finance_mcp/server.py
+++ b/finance_mcp/server.py
@@ -1189,7 +1189,8 @@ async def main():
             )
         )
 
-if __name__ == "__main__":
+def cli():
+    """Run the MCP server from console script entry points."""
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
@@ -1197,3 +1198,6 @@ if __name__ == "__main__":
     except Exception as e:
         logger.error(f"Server error: {str(e)}")
         raise
+
+if __name__ == "__main__":
+    cli()

--- a/finance_mcp/server.py
+++ b/finance_mcp/server.py
@@ -26,7 +26,7 @@ from mcp.types import (
 )
 import mcp.types as types
 
-from timezone_utils import create_timezone_info
+from .timezone_utils import create_timezone_info
 
 
 # Configure logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,4 @@ Repository = "https://github.com/akshatbindal/finance-mcp-server"
 Issues = "https://github.com/akshatbindal/finance-mcp-server/issues"
 
 [project.scripts]
-finance-mcp-server = "finance_mcp.server:main"
+finance-mcp-server = "finance_mcp.server:cli"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=read_requirements(),
     entry_points={
         "console_scripts": [
-            "finance-mcp-server=finance_mcp.server:main",
+            "finance-mcp-server=finance_mcp.server:cli",
         ],
     },
     keywords="mcp model-context-protocol finance stocks trading technical-analysis market-data yfinance",


### PR DESCRIPTION
## Summary
- fix the package import path for `timezone_utils` so the installed console script can import `finance_mcp.server`
- add a Dockerfile for running the stdio MCP server in a container
- add `.dockerignore` to keep local build/cache files out of the image context
- document both `uvx` and local Docker MCP client configurations

## Why
Issue #3 asks for easier `uvx` or Docker usage. While validating that path, the installed entry point failed before the server could start because `server.py` imported `timezone_utils` as a top-level module. Using a package-relative import makes the PyPI/uvx/console-script path work, and the Dockerfile gives users a containerized stdio option.

Closes #3.

## Validation
- Before the fix, `python -c "import finance_mcp.server"` failed with `ModuleNotFoundError: No module named 'timezone_utils'` after installing project dependencies.
- After the fix:
  - `python -m py_compile finance_mcp\\server.py finance_mcp\\timezone_utils.py`
  - `python -c "import finance_mcp.server; print(finance_mcp.server.main.__name__)"`
  - `python -c "from finance_mcp.server import main; print(main.__name__)"`
  - `git diff --check` (Windows CRLF warning only)

Docker build was not run locally because Docker is not installed in this environment (`docker` command not found).
