### PR TITLE
Align license metadata with Apache license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/finance-mcp-server.svg)](https://badge.fury.io/py/finance-mcp-server)
 [![Python Support](https://img.shields.io/pypi/pyversions/finance-mcp-server.svg)](https://pypi.org/project/finance-mcp-server/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 A powerful Model Context Protocol (MCP) server that brings comprehensive stock market data and technical analysis capabilities to Claude Desktop and other MCP-compatible clients.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "MCP Server for Financial Data and Technical Indicators"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 authors = [
     {name = "Akshat Bindal", email = "akshatbindal01@gmail.com"},
 ]
@@ -16,7 +16,7 @@ keywords = ["mcp", "finance", "stocks", "technical-analysis"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Topic :: Office/Business :: Financial",
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Intended Audience :: Financial and Insurance Industry",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
## Summary
- update the README license badge/link from MIT to Apache 2.0
- align `pyproject.toml` license metadata with the repository's Apache-2.0 `LICENSE` file
- update the setuptools classifier from MIT to Apache Software License

## Why
The repository's `LICENSE` file contains the Apache License 2.0 text, and the README license section already says the project is Apache licensed. The package metadata and badge still advertised MIT, which can mislead users checking PyPI metadata, classifiers, or the README badge before integrating the MCP server.

This PR does not change the actual license text; it only makes the surrounding metadata consistent with the existing `LICENSE` file.

## Validation
- `python -c "import tomllib; data=tomllib.load(open('pyproject.toml','rb')); print(data['project']['license'])"`
- `python -m py_compile setup.py`
- `git diff --check` (Windows CRLF warning only)
